### PR TITLE
feat: persist formData in localStorage

### DIFF
--- a/client/src/pages/Create.jsx
+++ b/client/src/pages/Create.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { FaSpinner } from "react-icons/fa";
 import axios from "axios";
 import Modal from "../components/Modal";
@@ -6,16 +6,22 @@ import { Toaster, toast } from "sonner";
 import Helmet from "react-helmet";
 
 export default function Create() {
-  const [formData, setFormData] = useState({
+  const localStorageFormData = JSON.parse(localStorage.getItem("formData"));
+  
+  const [formData, setFormData] = useState(localStorageFormData || {
     name: "",
     description: "",
     additionalInfo: "",
     skills: [],
-    skillInput: "", // Add skillInput property
+    skillInput: "",
   });
   const [generatedText, setGeneratedText] = useState("");
   const [showModal, setShowModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem("formData", JSON.stringify(formData));
+  }, [formData]);
 
   const validateForm = () => {
     if (formData.description === "") {

--- a/client/src/pages/Create.jsx
+++ b/client/src/pages/Create.jsx
@@ -7,7 +7,7 @@ import Helmet from "react-helmet";
 
 export default function Create() {
   const localStorageFormData = JSON.parse(localStorage.getItem("formData"));
-  
+
   const [formData, setFormData] = useState(localStorageFormData || {
     name: "",
     description: "",
@@ -101,6 +101,7 @@ export default function Create() {
           } else {
             setShowModal(true);
             toast.success("Cover Letter Generated");
+            localStorage.removeItem("formData");
           }
         } else {
           console.error("Invalid response format");


### PR DESCRIPTION
## Description

This PR address the issue #16 and adds the feature to persist form data.

## Changes Made

- Add functionality to store the formData in localStorage.
- Retrieve the stored formData(if any) on page load and populate the form.

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My code follows the coding guidelines of the project.
- [x] I have tested my changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] I have updated any necessary unit tests.
- [x] My commits follow the commit guidelines.

Fixes #16 
